### PR TITLE
Adding patching capabilities during model inference

### DIFF
--- a/deepsensor/data/loader.py
+++ b/deepsensor/data/loader.py
@@ -1365,8 +1365,11 @@ class TaskLoader:
         # define patch size in x1/x2
         x1_extend, x2_extend = patch_size
 
-        # define stride length in x1/x2
-        dy, dx = stride[0] * x1_extend, stride[1] * x2_extend
+        # define stride length in x1/x2 or set to patch_size if undefined
+        if stride is None:
+            stride = patch_size
+        
+        dy, dx = stride
 
         # Calculate the global bounds of context and target set.
         x1_min, x1_max, x2_min, x2_max = self.coord_bounds
@@ -1389,10 +1392,6 @@ class TaskLoader:
                 bbox = [y0, y0 + x1_extend, x0, x0 + x2_extend]
 
                 patch_list.append(bbox)
-
-        ## I don't think we should actually print this here, but somehow we should
-        ## provide this information back, so users know the number of patches per date.
-        print("Number of patches per date using sliding window method", len(patch_list))
 
         return patch_list
 

--- a/deepsensor/data/loader.py
+++ b/deepsensor/data/loader.py
@@ -1185,6 +1185,7 @@ class TaskLoader:
 
         task["time"] = date
         task["ops"] = []
+        task["bbox"] = bbox
         task["X_c"] = []
         task["Y_c"] = []
         if target_sampling is not None:

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -621,6 +621,47 @@ class DeepSensorModel(ProbabilisticModel):
         return pred
 
 
+    def predict_patch(        
+            self,
+            tasks: Union[List[Task], Task],
+            X_t: Union[
+                xr.Dataset,
+                xr.DataArray,
+                pd.DataFrame,
+                pd.Series,
+                pd.Index,
+                np.ndarray,
+            ],)-> Prediction:
+        
+        """
+        Predict patches and subsequently stiching patches to produce prediction at original extent. 
+        Predict on a regular grid or at off-grid locations.
+
+        Args:
+            tasks (List[Task] | Task):
+                List of tasks containing context data.
+            X_t (:class:`xarray.Dataset` | :class:`xarray.DataArray` | :class:`pandas.DataFrame` | :class:`pandas.Series` | :class:`pandas.Index` | :class:`numpy:numpy.ndarray`):
+                Target locations to predict at. Can be an xarray object
+                containingon-grid locations or a pandas object containing off-grid locations.
+        Returns:
+            :class:`~.model.pred.Prediction`):
+                A `dict`-like object mapping from target variable IDs to xarray or pandas objects
+                containing model predictions.
+                - If ``X_t`` is a pandas object, returns pandas objects
+                containing off-grid predictions.
+                - If ``X_t`` is an xarray object, returns xarray object
+                containing on-grid predictions.
+                - If ``n_samples`` == 0, returns only mean and std predictions.
+                - If ``n_samples`` > 0, returns mean, std and samples
+                predictions.
+        """
+
+        # Identify extent of original dataframe
+        for task in tasks:
+            pred = predict(task, X_t)
+
+        return pred
+
 def main():  # pragma: no cover
     import deepsensor.tensorflow
     from deepsensor.data.loader import TaskLoader

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -658,7 +658,7 @@ class DeepSensorModel(ProbabilisticModel):
 
         # Identify extent of original dataframe
         for task in tasks:
-            pred = predict(task, X_t)
+            pred = self.predict(task, X_t)
 
         return pred
 


### PR DESCRIPTION
Additional capabilities added to the predict_patch() function to:

- Conduct patchwise predictions by iteratively passing each patched task to predict()
- Stitch patchwise predictions to form xarray with same extent as original X_t. Stitching is done by trimming the extent of each patch and then using xr.combine_by_coords(). This means there is no overlap between trimmed pixels. This is because using averaging/ non-maximal suppression functions for overlapping patches produced ambiguous artefacts in the prediction. The stitching requires addition sub-tasks:
        - Calculate number of patches per row
        - Calculate overlap between adjacent patches
- Cast stitched prediction into DeepSensor.Prediction object.

This code has been tried on context/target sets containing two different input datasets. The output produced was identical to that generated using model.predict(). 
To do:

- Make code robust to predicting on multiple dates
- Try method when applied to Pandas objects.
- Compare outputs from predict_patch() and predict() for Tom's notebook. 
- Many other things. 