### PR TITLE
resolve unnormalised coordinate names

### DIFF
--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -757,7 +757,8 @@ class DeepSensorModel(ProbabilisticModel):
             """   
             patches_per_row = 0
             vars = list(preds[0][0].data_vars)
-            var = vars[0]    
+            
+            var = vars[0]  
             y_val = preds[0][0][var].coords[unnorm_coord_names['x1']].min()  
               
             for p in preds:
@@ -803,7 +804,6 @@ class DeepSensorModel(ProbabilisticModel):
             x_overlap_index = int(np.ceil((np.argmin(np.abs(X_t_ds.coords[unnorm_coord_names['x1']].values - unnorm_overlap_x1))/2)))
             y_overlap_index = int(np.ceil((np.argmin(np.abs(X_t_ds.coords[unnorm_coord_names['x2']].values - unnorm_overlap_x2))/2)))
             xy_overlap = (x_overlap_index, y_overlap_index)
-
             return xy_overlap
 
         def get_index(*args, x1 = True) -> Union[int, Tuple[List[int], List[int]]]:
@@ -918,7 +918,6 @@ class DeepSensorModel(ProbabilisticModel):
         preds = []
         for task in tasks:
             bbox = task['bbox']
-
             # Unnormalise coordinates of bounding box of patch
             x1 = xr.DataArray([bbox[0], bbox[1]], dims='x1', name='x1')
             x2 = xr.DataArray([bbox[2], bbox[3]], dims='x2', name='x2')
@@ -938,9 +937,11 @@ class DeepSensorModel(ProbabilisticModel):
             pred = self.predict(task, task_X_t)
             # Append patchwise DeepSensor prediction object to list
             preds.append(pred)
-          
+
+        
         overlap_norm = tuple(patch - stride for patch, stride in zip(patch_size, stride_size))
         patch_overlap_unnorm = get_patch_overlap(overlap_norm, data_processor, X_t)
+        
         patches_per_row = get_patches_per_row(preds)
         stitched_prediction = stitch_clipped_predictions(preds, patch_overlap_unnorm, patches_per_row)
         

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -736,7 +736,14 @@ class DeepSensorModel(ProbabilisticModel):
                 If ``append_indexes`` are not all the same length as ``X_t``.
         """
         
-        def get_patches_per_row(preds, X_t) -> int:
+        # Get coordinate names of original unnormalised dataset.
+        unnorm_coord_names = {
+                "x1": self.data_processor.raw_spatial_coord_names[0],
+                "x2": self.data_processor.raw_spatial_coord_names[1],
+            }
+
+
+        def get_patches_per_row(preds) -> int:
             """
             Calculate number of patches per row. 
             Required to stitch patches back together. 
@@ -751,10 +758,10 @@ class DeepSensorModel(ProbabilisticModel):
             patches_per_row = 0
             vars = list(preds[0][0].data_vars)
             var = vars[0]    
-            y_val = preds[0][0][var].coords['y'].min()  
+            y_val = preds[0][0][var].coords[unnorm_coord_names['x1']].min()  
               
             for p in preds:
-                if p[0][var].coords['y'].min() == y_val:
+                if p[0][var].coords[unnorm_coord_names['x1']].min() == y_val:
                     patches_per_row = patches_per_row + 1  
 
             return patches_per_row
@@ -789,12 +796,12 @@ class DeepSensorModel(ProbabilisticModel):
             
             # Unnormalise coordinates of bounding boxes
             overlap_unnorm_xr = data_processor.unnormalise(overlap_norm_xr)
-            unnorm_overlap_x1 = overlap_unnorm_xr.coords['x'].values[1]
-            unnorm_overlap_x2 = overlap_unnorm_xr.coords['y'].values[1]
+            unnorm_overlap_x1 = overlap_unnorm_xr.coords[unnorm_coord_names['x1']].values[1]
+            unnorm_overlap_x2 = overlap_unnorm_xr.coords[unnorm_coord_names['x2']].values[1]
 
             # Find the position of these indices within the DataArray
-            x_overlap_index = int(np.ceil((np.argmin(np.abs(X_t_ds.coords['x'].values - unnorm_overlap_x1))/2)))
-            y_overlap_index = int(np.ceil((np.argmin(np.abs(X_t_ds.coords['y'].values - unnorm_overlap_x2))/2)))
+            x_overlap_index = int(np.ceil((np.argmin(np.abs(X_t_ds.coords[unnorm_coord_names['x1']].values - unnorm_overlap_x1))/2)))
+            y_overlap_index = int(np.ceil((np.argmin(np.abs(X_t_ds.coords[unnorm_coord_names['x2']].values - unnorm_overlap_x2))/2)))
             xy_overlap = (x_overlap_index, y_overlap_index)
 
             return xy_overlap
@@ -824,15 +831,15 @@ class DeepSensorModel(ProbabilisticModel):
             if len(args) == 1:
                 patch_coord = args
                 if x1:
-                    coord_index = np.argmin(np.abs(X_t.coords['y'].values - patch_coord))
+                    coord_index = np.argmin(np.abs(X_t.coords[unnorm_coord_names['x1']].values - patch_coord))
                 else:
-                    coord_index = np.argmin(np.abs(X_t.coords['x'].values - patch_coord)) 
+                    coord_index = np.argmin(np.abs(X_t.coords[unnorm_coord_names['x2']].values - patch_coord)) 
                 return coord_index
 
             elif len(args) == 2:
                 patch_x1, patch_x2 = args       
-                x1_index = [np.argmin(np.abs(X_t.coords['y'].values - target_x1)) for target_x1 in patch_x1]           
-                x2_index = [np.argmin(np.abs(X_t.coords['x'].values - target_x2)) for target_x2 in patch_x2]
+                x1_index = [np.argmin(np.abs(X_t.coords[unnorm_coord_names['x1']].values - target_x1)) for target_x1 in patch_x1]           
+                x2_index = [np.argmin(np.abs(X_t.coords[unnorm_coord_names['x2']].values - target_x2)) for target_x2 in patch_x2]
                 return (x1_index, x2_index)
             
         
@@ -856,9 +863,11 @@ class DeepSensorModel(ProbabilisticModel):
             combined: dict
                 Dictionary object containing the stitched model predictions.
             """
+
+
             
-            data_x1 = X_t.coords['y'].min().values, X_t.coords['y'].max().values
-            data_x2 = X_t.coords['x'].min().values, X_t.coords['x'].max().values   
+            data_x1 = X_t.coords[unnorm_coord_names['x1']].min().values, X_t.coords[unnorm_coord_names['x1']].max().values
+            data_x2 = X_t.coords[unnorm_coord_names['x2']].min().values, X_t.coords[unnorm_coord_names['x2']].max().values   
             data_x1_index, data_x2_index = get_index(data_x1, data_x2)
             patches_clipped = {var_name: [] for var_name in patch_preds[0].keys()}
 
@@ -867,20 +876,20 @@ class DeepSensorModel(ProbabilisticModel):
                 for var_name, data_array in patch_pred.items(): #previously patch
                     if var_name in patch_pred:
                         # Get row/col index values of each patch
-                        patch_x1 = data_array.coords['y'].min().values, data_array.coords['y'].max().values
-                        patch_x2 = data_array.coords['x'].min().values, data_array.coords['x'].max().values
+                        patch_x1 = data_array.coords[unnorm_coord_names['x1']].min().values, data_array.coords[unnorm_coord_names['x1']].max().values
+                        patch_x2 = data_array.coords[unnorm_coord_names['x2']].min().values, data_array.coords[unnorm_coord_names['x2']].max().values
                         patch_x1_index, patch_x2_index =  get_index(patch_x1, patch_x2)
                         
                         b_x1_min, b_x1_max = patch_overlap[0], patch_overlap[0]
                         b_x2_min, b_x2_max = patch_overlap[1], patch_overlap[1]
                         # Do not remove border for the patches along top and left of dataset
-                        # and change overlap size for last patch in rows and columns.
+                        # and change overlap size for last patch in each row and column.
                         if patch_x2_index[0] == data_x2_index[0]:
                             b_x2_min = 0
                         elif patch_x2_index[1] == data_x2_index[1]:
                             b_x2_max = 0
                             patch_row_prev = preds[i-1]
-                            prev_patch_x2_max = get_index(int(patch_row_prev[var_name].coords['x'].max()), x1 = False)
+                            prev_patch_x2_max = get_index(int(patch_row_prev[var_name].coords[unnorm_coord_names['x2']].max()), x1 = False)
                             b_x2_min = (prev_patch_x2_max - patch_x2_index[0])-patch_overlap[1]
 
                         if patch_x1_index[0] == data_x1_index[0]:
@@ -888,13 +897,13 @@ class DeepSensorModel(ProbabilisticModel):
                         elif abs(patch_x1_index[1] - data_x1_index[1])<2:
                             b_x1_max = 0
                             patch_prev = preds[i-patches_per_row]
-                            prev_patch_x1_max = get_index(int(patch_prev[var_name].coords['y'].max()), x1 = True)
+                            prev_patch_x1_max = get_index(int(patch_prev[var_name].coords[unnorm_coord_names['x1']].max()), x1 = True)
                             b_x1_min = (prev_patch_x1_max - patch_x1_index[0])- patch_overlap[0]
 
                         patch_clip_x1_min = int(b_x1_min)
-                        patch_clip_x1_max = int(data_array.sizes['y'] - b_x1_max)
+                        patch_clip_x1_max = int(data_array.sizes[unnorm_coord_names['x1']] - b_x1_max)
                         patch_clip_x2_min = int(b_x2_min)
-                        patch_clip_x2_max = int(data_array.sizes['x'] - b_x2_max)
+                        patch_clip_x2_max = int(data_array.sizes[unnorm_coord_names['x2']] - b_x2_max)
 
                         patch_clip = data_array.isel(y=slice(patch_clip_x1_min, patch_clip_x1_max),
                                                     x=slice(patch_clip_x2_min, patch_clip_x2_max))
@@ -915,11 +924,16 @@ class DeepSensorModel(ProbabilisticModel):
             x2 = xr.DataArray([bbox[2], bbox[3]], dims='x2', name='x2')
             bbox_norm = xr.Dataset(coords={'x1': x1, 'x2': x2})
             bbox_unnorm = data_processor.unnormalise(bbox_norm)
-            unnorm_bbox_x1 = bbox_unnorm['x'].values.min(), bbox_unnorm['x'].values.max()
-            unnorm_bbox_x2 = bbox_unnorm['y'].values.min(), bbox_unnorm['y'].values.max()
+            unnorm_bbox_x1 = bbox_unnorm[unnorm_coord_names['x1']].values.min(), bbox_unnorm[unnorm_coord_names['x1']].values.max()
+            unnorm_bbox_x2 = bbox_unnorm[unnorm_coord_names['x2']].values.min(), bbox_unnorm[unnorm_coord_names['x2']].values.max()
+            
             # Determine X_t for patch
-            task_X_t = X_t.sel(x = slice(unnorm_bbox_x1[0], unnorm_bbox_x1[1]),
-                                y = slice(unnorm_bbox_x2[0], unnorm_bbox_x2[1]))
+            task_extent_dict = {
+                unnorm_coord_names['x1']: slice(unnorm_bbox_x1[0], unnorm_bbox_x1[1]),
+                unnorm_coord_names['x2']: slice(unnorm_bbox_x2[0], unnorm_bbox_x2[1])
+            }
+            task_X_t = X_t.sel(**task_extent_dict)
+
             # Patchwise prediction
             pred = self.predict(task, task_X_t)
             # Append patchwise DeepSensor prediction object to list
@@ -927,7 +941,7 @@ class DeepSensorModel(ProbabilisticModel):
           
         overlap_norm = tuple(patch - stride for patch, stride in zip(patch_size, stride_size))
         patch_overlap_unnorm = get_patch_overlap(overlap_norm, data_processor, X_t)
-        patches_per_row = get_patches_per_row(preds, X_t)
+        patches_per_row = get_patches_per_row(preds)
         stitched_prediction = stitch_clipped_predictions(preds, patch_overlap_unnorm, patches_per_row)
         
         ## Cast prediction into DeepSensor.Prediction object.
@@ -938,7 +952,7 @@ class DeepSensorModel(ProbabilisticModel):
         for var_name_copy, data_array_copy in prediction.items():
 
             # set x and y coords
-            stitched_preds = xr.Dataset(coords={'x': X_t['x'], 'y': X_t['y']})
+            stitched_preds = xr.Dataset(coords={'x1': X_t[unnorm_coord_names['x1']], 'x2': X_t[unnorm_coord_names['x2']]})
 
             # Set time to same as patched prediction
             stitched_preds['time'] = data_array_copy['time']


### PR DESCRIPTION
Change 'x' and 'y' to unnorm_coord_names['x1'] and unnorm_coord_names['x2'] throughout model.py so code is agnostic to the original coordinate names. 