### PR TITLE
For patchwise prediction, get `patch_size` and `stride` directly from task

### DIFF
--- a/deepsensor/data/loader.py
+++ b/deepsensor/data/loader.py
@@ -959,6 +959,8 @@ class TaskLoader:
         ] = None,
         split_frac: float = 0.5,
         bbox: Sequence[float] = None,
+        patch_size: Union[float, tuple[float]] = None,
+        stride: Union[float, tuple[float]] = None,
         datewise_deterministic: bool = False,
         seed_override: Optional[int] = None,
     ) -> Task:
@@ -995,6 +997,10 @@ class TaskLoader:
         bbox : Sequence[float], optional
             Bounding box to spatially slice the data, should be of the form [x1_min, x1_max, x2_min, x2_max].
             Useful when considering the entire available region is computationally prohibitive for model forward pass.
+        patch_size : Union(Tuple|float), optional
+            Only used by patchwise inference. Height and width of patch in x1/x2 normalised coordinates.
+        stride: Union(Tuple|float), optional
+            Only used by patchwise inference. Length of stride between adjacent patches in x1/x2 normalised coordinates.
         datewise_deterministic : bool
             Whether random sampling is datewise_deterministic based on the
             date. Default is ``False``.
@@ -1186,6 +1192,8 @@ class TaskLoader:
         task["time"] = date
         task["ops"] = []
         task["bbox"] = bbox
+        task["patch_size"] = patch_size # store patch_size and stride in task for use in stitching in prediction
+        task["stride"] = stride
         task["X_c"] = []
         task["Y_c"] = []
         if target_sampling is not None:
@@ -1620,6 +1628,8 @@ class TaskLoader:
                                 split_frac=split_frac,
                                 datewise_deterministic=datewise_deterministic,
                                 seed_override=seed_override,
+                                patch_size=patch_size,
+                                stride=stride
                             )
                             for bbox in bboxes
                         ]
@@ -1635,6 +1645,8 @@ class TaskLoader:
                         split_frac=split_frac,
                         datewise_deterministic=datewise_deterministic,
                         seed_override=seed_override,
+                        patch_size=patch_size,
+                        stride=stride
                     )
                     for bbox in bboxes
                 ]

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -638,8 +638,6 @@ class DeepSensorModel(ProbabilisticModel):
             pd.DataFrame,
             List[Union[xr.DataArray, xr.Dataset, pd.DataFrame]],
         ],
-        stride_size: Union[float, tuple[float]],
-        patch_size: Union[float, tuple[float]],
         X_t_mask: Optional[Union[xr.Dataset, xr.DataArray]] = None,
         X_t_is_normalised: bool = False,
         aux_at_targets_override: Union[xr.Dataset, xr.DataArray] = None,
@@ -664,10 +662,6 @@ class DeepSensorModel(ProbabilisticModel):
                 List of tasks containing context data.
             data_processor (:class:`~.data.processor.DataProcessor`):
                 Used for unnormalising the coordinates of the bounding boxes of patches.
-            stride_size (Union[float, tuple[float]]):
-                Length of stride between adjacent patches in x1/x2 normalised coordinates.
-            patch_size (Union[float, tuple[float]]):
-                Height and width of patch in x1/x2 normalised coordinates.
             X_t (:class:`xarray.Dataset` | :class:`xarray.DataArray` | :class:`pandas.DataFrame` | :class:`pandas.Series` | :class:`pandas.Index` | :class:`numpy:numpy.ndarray`):
                 Target locations to predict at. Can be an xarray object
                 containingon-grid locations or a pandas object containing off-grid locations.
@@ -938,8 +932,7 @@ class DeepSensorModel(ProbabilisticModel):
             # Append patchwise DeepSensor prediction object to list
             preds.append(pred)
 
-        
-        overlap_norm = tuple(patch - stride for patch, stride in zip(patch_size, stride_size))
+        overlap_norm = tuple(patch - stride for patch, stride in zip(task["patch_size"], task["stride"]))
         patch_overlap_unnorm = get_patch_overlap(overlap_norm, data_processor, X_t)
         
         patches_per_row = get_patches_per_row(preds)


### PR DESCRIPTION
At present for patchwise prediction, we use `patch_size` and `stride` as arguments to the task loader to create tasks for prediction. We then give (hopefully) those same values of `patch_size` and `stride` to `predict_patch` as arguments so that it can stitch them together.

Perhaps a minor point, but I'd prefer that we don't use these same arguments in two places as it is an opportunity for error and possibly weird results if different values are passed in, however unlikely.

In this PR I attempt to resolve this by storing `patch_size` and `stride` in the `task` object in the `task_generation`, which can then be used by `predict_patch` directly.

@MartinSJRogers and I had previously discussed re-calculating these values from `bbox` - though in hindsight, this seems a bit silly when we have access to these numbers.

Let me know what you think.